### PR TITLE
Feat :: device & book rental logic

### DIFF
--- a/src/main/java/com/keepgoing/keepserver/domain/device/entity/Device.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/entity/Device.java
@@ -32,10 +32,10 @@ public class Device {
         기기 대여 상태
     */
     @Column(nullable = false)
-    private int status;  /* 1 대여 가능, 2 대여 불가능 */
+    private boolean status;
 
     @Builder
-    public Device(String deviceName, int status, String imgUrl) {
+    public Device(String deviceName, boolean status, String imgUrl) {
         this.deviceName = deviceName;
         this.status = status;
         this.imgUrl = imgUrl;

--- a/src/main/java/com/keepgoing/keepserver/domain/device/payload/request/DeviceDto.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/payload/request/DeviceDto.java
@@ -7,6 +7,6 @@ public record DeviceDto (
         Long id,
         String deviceName,
         String imgUrl,
-        int status
+        boolean status
 ){
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/DeviceResponseDto.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/DeviceResponseDto.java
@@ -7,5 +7,5 @@ public record DeviceResponseDto(
         Long id,
         String deviceName,
         String imgUrl,
-        int status) {
+        boolean status) {
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/MyDevicesDto.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/MyDevicesDto.java
@@ -1,10 +1,8 @@
 package com.keepgoing.keepserver.domain.device.payload.response;
 
 import lombok.Builder;
-import lombok.Data;
 
 @Builder
-@Data
 public record MyDevicesDto (
         Long id,
         String deviceName ) {

--- a/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/MyDevicesDto.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/payload/response/MyDevicesDto.java
@@ -1,0 +1,11 @@
+package com.keepgoing.keepserver.domain.device.payload.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public record MyDevicesDto (
+        Long id,
+        String deviceName ) {
+}

--- a/src/main/java/com/keepgoing/keepserver/domain/device/presentation/DeviceController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/presentation/DeviceController.java
@@ -47,4 +47,10 @@ public class DeviceController {
     public BaseResponse deleteDevice(@PathVariable Long id, Authentication authentication){
         return deviceService.deleteDevice(id, authentication);
     }
+
+    @Operation(summary = "기자재 대여", description = "기자재를 대여합니다.")
+    @PostMapping("/rent")
+    public BaseResponse rentDevice(@RequestParam String deviceName, @RequestParam String email) {
+        return deviceService.rentDevice(deviceName, email);
+    }
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
     List<Device> findByDeviceNameContaining(String deviceName, Sort id);
-    Device findByDeviceName(String deviceName);
+
+    Optional<Device> findByDeviceName(String deviceName);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
     List<Device> findByDeviceNameContaining(String deviceName, Sort id);
+    Device findByDeviceName(String deviceName);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
@@ -3,6 +3,7 @@ package com.keepgoing.keepserver.domain.device.service;
 import com.keepgoing.keepserver.domain.device.entity.Device;
 import com.keepgoing.keepserver.domain.device.payload.request.DeviceDto;
 import com.keepgoing.keepserver.domain.device.payload.response.DeviceResponseDto;
+import com.keepgoing.keepserver.domain.device.payload.response.MyDevicesDto;
 import com.keepgoing.keepserver.global.common.BaseResponse;
 import org.springframework.security.core.Authentication;
 
@@ -32,6 +33,12 @@ public interface DeviceService {
                 .deviceName((dto.deviceName()))
                 .imgUrl(dto.imgUrl())
                 .status(dto.status())
+                .build();
+    }
+
+    default MyDevicesDto entityToDto(MyDevicesDto myDevicesDto) {
+        return MyDevicesDto.builder()
+                .id(myDevicesDto.id())
                 .build();
     }
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
@@ -24,7 +24,7 @@ public interface DeviceService {
                 .id(entity.getId())
                 .deviceName((entity.getDeviceName()))
                 .imgUrl(entity.getImgUrl())
-                .status(entity.getStatus())
+                .status(entity.isStatus())
                 .build();
     }
 

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
@@ -36,9 +36,10 @@ public interface DeviceService {
                 .build();
     }
 
-    default MyDevicesDto entityToDto(MyDevicesDto myDevicesDto) {
+    default MyDevicesDto entityToDto(MyDevicesDto dto) {
         return MyDevicesDto.builder()
-                .id(myDevicesDto.id())
+                .id(dto.id())
+                .deviceName(dto.deviceName())
                 .build();
     }
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
@@ -18,6 +18,7 @@ public interface DeviceService {
     BaseResponse deleteDevice(Long id, Authentication authentication);
 
     BaseResponse findAll();
+    BaseResponse rentDevice(String deviceName, String email);
 
     default DeviceResponseDto entityToDto(Device entity) {
         return DeviceResponseDto.builder()

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceService.java
@@ -35,11 +35,4 @@ public interface DeviceService {
                 .status(dto.status())
                 .build();
     }
-
-    default MyDevicesDto entityToDto(MyDevicesDto dto) {
-        return MyDevicesDto.builder()
-                .id(dto.id())
-                .deviceName(dto.deviceName())
-                .build();
-    }
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -59,14 +59,23 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     public BaseResponse myDevices(Authentication authentication) {
-        String userName = userRepository.findByEmail(authentication.getName()).orElseThrow(DeviceException::userNotFound).getEmail();
+        String userName = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(DeviceException::userNotFound).getEmail();
+
         List<Device> devices = deviceRepository.findByDeviceNameContaining(userName, (Sort.by(Sort.Direction.DESC, "id")));
 
-        List<DeviceResponseDto> deviceResponseDtos = new ArrayList<>(devices.stream()
-                .map(this::entityToDto)
-                .toList());
+        List<DeviceResponseDto> deviceResponseDtos = convertDevicesToDtos(devices);
 
         return new BaseResponse(HttpStatus.OK, "기기 불러오기 성공", deviceResponseDtos);
+    }
+
+    private List<DeviceResponseDto> convertDevicesToDtos(List<Device> devices) {
+        List<DeviceResponseDto> deviceResponseDtos = new ArrayList<>();
+        for (Device device : devices) {
+            DeviceResponseDto dto = entityToDto(device);
+            deviceResponseDtos.add(dto);
+        }
+        return deviceResponseDtos;
     }
 
     private User findUserByEmail(String email) {

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -72,12 +72,17 @@ public class DeviceServiceImpl implements DeviceService {
     @Override
     public BaseResponse rentDevice(String deviceName, String email) {
         Device device = deviceRepository.findByDeviceName(deviceName);
-        if (device != null && !device.isStatus()) {
-            device.setStatus(true);
-            deviceRepository.save(device);
-            return new BaseResponse(HttpStatus.OK, "기기 대여 성공", entityToDto(device));
+        if (device == null) {
+            throw DeviceException.notFoundDevice();
         }
-        return new BaseResponse(HttpStatus.BAD_REQUEST, "기기 대여 실패");
+
+        if (device.isStatus()) {
+            throw DeviceException.deviceAlreadyRented();
+        }
+
+        device.setStatus(true);
+        deviceRepository.save(device);
+        return new BaseResponse(HttpStatus.OK, "기기 대여 성공", entityToDto(device));
     }
 
     private List<DeviceResponseDto> convertDevicesToDtos(List<Device> devices) {

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -69,6 +69,17 @@ public class DeviceServiceImpl implements DeviceService {
         return new BaseResponse(HttpStatus.OK, "기기 불러오기 성공", deviceResponseDtos);
     }
 
+    @Override
+    public BaseResponse rentDevice(String deviceName, String email) {
+        Device device = deviceRepository.findByDeviceName(deviceName);
+        if (device != null && !device.isStatus()) {
+            device.setStatus(true);
+            deviceRepository.save(device);
+            return new BaseResponse(HttpStatus.OK, "기기 대여 성공", entityToDto(device));
+        }
+        return new BaseResponse(HttpStatus.BAD_REQUEST, "기기 대여 실패");
+    }
+
     private List<DeviceResponseDto> convertDevicesToDtos(List<Device> devices) {
         List<DeviceResponseDto> deviceResponseDtos = new ArrayList<>();
         for (Device device : devices) {

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -71,17 +71,10 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     public BaseResponse rentDevice(String deviceName, String email) {
-        Device device = deviceRepository.findByDeviceName(deviceName);
-        if (device == null) {
-            throw DeviceException.notFoundDevice();
-        }
+        Device device = findDeviceByName(deviceName);
+        validateDeviceAvailability(device);
+        rentDeviceToUser(device);
 
-        if (device.isStatus()) {
-            throw DeviceException.deviceAlreadyRented();
-        }
-
-        device.setStatus(true);
-        deviceRepository.save(device);
         return new BaseResponse(HttpStatus.OK, "기기 대여 성공", entityToDto(device));
     }
 
@@ -110,5 +103,21 @@ public class DeviceServiceImpl implements DeviceService {
             throw new DeviceException(DeviceError.DEVICE_NOT_FOUND_EXCEPTION);
         }
         deviceRepository.deleteById(id);
+    }
+
+    private Device findDeviceByName(String deviceName) {
+        return deviceRepository.findByDeviceName(deviceName)
+                .orElseThrow(DeviceException::notFoundDevice);
+    }
+
+    private void validateDeviceAvailability(Device device) {
+        if (device.isStatus()) {
+            throw DeviceException.deviceAlreadyRented();
+        }
+    }
+
+    private void rentDeviceToUser(Device device) {
+        device.setStatus(true);
+        deviceRepository.save(device);
     }
 }

--- a/src/main/java/com/keepgoing/keepserver/global/exception/device/DeviceError.java
+++ b/src/main/java/com/keepgoing/keepserver/global/exception/device/DeviceError.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum DeviceError implements ErrorProperty {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
-    DEVICE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 기기를 찾을 수 없습니다.");
+    DEVICE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 기기를 찾을 수 없습니다."),
+    DEVICE_ALREADY_RENTED(HttpStatus.BAD_REQUEST, "기기가 이미 대여 중입니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/keepgoing/keepserver/global/exception/device/DeviceException.java
+++ b/src/main/java/com/keepgoing/keepserver/global/exception/device/DeviceException.java
@@ -6,6 +6,7 @@ public class DeviceException extends BusinessException {
     private static final DeviceException USER_NOT_FOUND = new DeviceException(DeviceError.USER_NOT_FOUND);
 
     private static final DeviceException DEVICE_NOT_FOUND_EXCEPTION = new DeviceException(DeviceError.DEVICE_NOT_FOUND_EXCEPTION);
+    private static final DeviceException DEVICE_ALREADY_RENTED = new DeviceException(DeviceError.DEVICE_ALREADY_RENTED);
 
     public DeviceException(DeviceError error) {
         super(error);
@@ -17,5 +18,8 @@ public class DeviceException extends BusinessException {
 
     public static DeviceException notFoundDevice() {
         return DEVICE_NOT_FOUND_EXCEPTION;
+    }
+    public static DeviceException deviceAlreadyRented() {
+        return DEVICE_ALREADY_RENTED;
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #33 

## 작업 내용
1.  기자재 대여 api `/rent`개발
2. 기자재 대여여부 `status` type `boolean` 으로 변경
3. `device error code` 및 `exception` 추가
5. `deviceName` 변수명 변경
6. `SRP` 적용

대여 로직이 구현되었으니 빠르게 #29 #35 이슈 해결하겠습니다.

## 궁금한 점
서비스는 현재 기자재와 도서를 대여할 수 있고, 이 두 가지의 서비스 흐름은 동일합니다.
지금 `rentDevice` 함수가 기자재 대여에 사용되고 있는데, 이와 동일한 로직이 도서 대여 시에도 필요합니다. 
**이러한 경우에는 `rentBook` 함수를 따로 만드는 것이 바람직할지, 
아니면 함수명을 `rent`로 변경하여 두 곳에서 공통으로 사용하는 것이 좋을지 궁금합니다.**