### PR TITLE
Fix :: fix user device rental information list & rent logic

### DIFF
--- a/src/main/java/com/keepgoing/keepserver/domain/device/entity/Device.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/entity/Device.java
@@ -1,5 +1,6 @@
 package com.keepgoing.keepserver.domain.device.entity;
 
+import com.keepgoing.keepserver.domain.user.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -33,6 +34,13 @@ public class Device {
     */
     @Column(nullable = false)
     private boolean status;
+
+    /*
+        대여자 id
+    */
+    @ManyToOne
+    @JoinColumn(name = "borrower_id")
+    private User borrower;
 
     @Builder
     public Device(String deviceName, boolean status, String imgUrl) {

--- a/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
@@ -1,14 +1,10 @@
 package com.keepgoing.keepserver.domain.device.repository;
 
 import com.keepgoing.keepserver.domain.device.entity.Device;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
-    List<Device> findByDeviceNameContaining(String deviceName, Sort id);
-
     Optional<Device> findByDeviceName(String deviceName);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/repository/DeviceRepository.java
@@ -1,10 +1,13 @@
 package com.keepgoing.keepserver.domain.device.repository;
 
 import com.keepgoing.keepserver.domain.device.entity.Device;
+import com.keepgoing.keepserver.domain.user.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DeviceRepository extends JpaRepository<Device, Long> {
     Optional<Device> findByDeviceName(String deviceName);
+    List<Device> findByBorrower(User borrower);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -68,8 +68,10 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     public BaseResponse rentDevice(String deviceName, String email) {
+        User user = findUserByEmail(email);
         Device device = findDeviceByName(deviceName);
         validateDeviceAvailability(device);
+        device.setBorrower(user);
         rentDeviceToUser(device);
 
         return new BaseResponse(HttpStatus.OK, "기기 대여 성공", entityToDto(device));

--- a/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/device/service/DeviceServiceImpl.java
@@ -59,14 +59,11 @@ public class DeviceServiceImpl implements DeviceService {
 
     @Override
     public BaseResponse myDevices(Authentication authentication) {
-        String userName = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(DeviceException::userNotFound).getEmail();
-
-        List<Device> devices = deviceRepository.findByDeviceNameContaining(userName, (Sort.by(Sort.Direction.DESC, "id")));
-
+        User user = findUserByEmail(authentication.getName());
+        List<Device> devices = findDevicesBorrowedByUser(user);
         List<DeviceResponseDto> deviceResponseDtos = convertDevicesToDtos(devices);
 
-        return new BaseResponse(HttpStatus.OK, "기기 불러오기 성공", deviceResponseDtos);
+        return new BaseResponse(HttpStatus.OK, "유저가 대여한 기기 목록 조회 성공", deviceResponseDtos);
     }
 
     @Override
@@ -90,6 +87,10 @@ public class DeviceServiceImpl implements DeviceService {
     private User findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(
                 () -> new DeviceException(DeviceError.USER_NOT_FOUND));
+    }
+
+    private List<Device> findDevicesBorrowedByUser(User user) {
+        return deviceRepository.findByBorrower(user);
     }
 
     private void validateTeacher(User user) {


### PR DESCRIPTION
## 관련 이슈
- #35 

## 작업 내용
기존에 문제가 있었던 유저 기자재 대여 정보 리스트 불러오는 `myDevices` 서비스 로직을 수정 했습니다.
또한 `rentDevice` 함수에서 기자재 대여 시 유저의 이메일을 저장 하는 로직이 빠져있어서 추가 했습니다.