### PR TITLE
Fix :: s3 ACL error

### DIFF
--- a/src/main/java/com/keepgoing/keepserver/global/common/S3/S3Uploader.java
+++ b/src/main/java/com/keepgoing/keepserver/global/common/S3/S3Uploader.java
@@ -43,7 +43,6 @@ public class S3Uploader {
     private String putS3(File uploadFile, String fileName) {
         amazonS3Client.putObject(
                 new PutObjectRequest(bucket, fileName, uploadFile)
-                        .withCannedAcl(CannedAccessControlList.PublicRead)    // PublicRead 권한으로 업로드 됨
         );
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }


### PR DESCRIPTION
## 작업 내용
기존 `s3` 사진 업로딩 시에 `ACL`을 통한 `getObject`를 `Bucket 정책`을 통해 되게 수정하였습니다
