### PR TITLE
Feature/new requirement

### DIFF
--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -53,7 +53,7 @@ public class Item {
     /*
         사용자
     */
-    @Column(name = "rentedBy", nullable = true)
+    @Column(name = "rented_by", nullable = true)
     private String rentedBy;
 
     /*

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepserver.domain.teacher.domain.entity;
 
 import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemUpdateRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -100,6 +101,42 @@ public class Item {
 
     public void updateStatus(ItemStatus status) {
         this.status = status;
+    }
+
+    public void updateItem(ItemUpdateRequest dto) {
+        if (dto.item() != null) {
+            this.item = dto.item();
+        }
+        if (dto.details() != null) {
+            this.details = dto.details();
+        }
+        if (dto.serialNumber() != null) {
+            this.serialNumber = dto.serialNumber();
+        }
+        if (dto.acquisitionDate() != null) {
+            this.acquisitionDate = dto.acquisitionDate();
+        }
+        if (dto.price() != null) {
+            this.price = dto.price();
+        }
+        if (dto.rentedBy() != null) {
+            this.rentedBy = dto.rentedBy();
+        }
+        if (dto.place() != null) {
+            this.place = dto.place();
+        }
+        if (dto.returnDate() != null) {
+            this.returnDate = dto.returnDate();
+        }
+        if (dto.rentalDate() != null) {
+            this.rentalDate = dto.rentalDate();
+        }
+        if (dto.usageDate() != null) {
+            this.usageDate = dto.usageDate();
+        }
+        if (dto.status() != null) {
+            this.status = dto.status();
+        }
     }
 
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -52,7 +52,7 @@ public class Item {
     /*
         사용자
     */
-    @Column(name = "user", nullable = false)
+    @Column(name = "user", nullable = true)
     private String user;
 
     /*
@@ -64,13 +64,13 @@ public class Item {
     /*
         반납일
     */
-    @Column(name = "return_date", nullable = false)
+    @Column(name = "return_date", nullable = true)
     private LocalDateTime returnDate;
 
     /*
         대여일
     */
-    @Column(name = "rental_date", nullable = false)
+    @Column(name = "rental_date", nullable = true)
     private LocalDateTime rentalDate;
 
     /*

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -47,13 +47,13 @@ public class Item {
         취득 단가
     */
     @Column(name = "price", nullable = false)
-    private String price;
+    private Long price;
 
     /*
         사용자
     */
-    @Column(name = "user", nullable = true)
-    private String user;
+    @Column(name = "rentedBy", nullable = true)
+    private String rentedBy;
 
     /*
         기기 위치
@@ -84,18 +84,18 @@ public class Item {
     private ItemStatus status = ItemStatus.AVAILABLE;
 
     @Builder
-    public Item(String item, String details, String serialNumber, LocalDateTime acquisitionDate, String price, String user, String place, LocalDateTime returnDate, LocalDateTime rentalDate, Long usageDate, ItemStatus status) {
+    public Item(String item, String details, String serialNumber, LocalDateTime acquisitionDate, Long price, String rentedBy, String place, LocalDateTime returnDate, LocalDateTime rentalDate, Long usageDate, ItemStatus status) {
         this.item = item;
         this.details = details;
         this.serialNumber = serialNumber;
         this.acquisitionDate = acquisitionDate;
         this.price = price;
-        this.user = user;
+        this.rentedBy = rentedBy;
         this.place = place;
         this.returnDate = returnDate;
         this.rentalDate = rentalDate;
         this.usageDate = usageDate;
-        this.status = status;
+        this.status = status != null ? status : ItemStatus.AVAILABLE;
     }
 
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -98,4 +98,8 @@ public class Item {
         this.status = status != null ? status : ItemStatus.AVAILABLE;
     }
 
+    public void updateStatus(ItemStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -56,7 +56,7 @@ public class Item {
     private String user;
 
     /*
-        대여 위치
+        기기 위치
     */
     @Column(name = "place", nullable = false)
     private String place;

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/domain/entity/Item.java
@@ -26,6 +26,12 @@ public class Item {
     private String item;
 
     /*
+        세부 제품명
+    */
+    @Column(name = "details", nullable = false)
+    private String details;
+
+    /*
         분류 번호
     */
     @Column(name = "serial_number", nullable = false)
@@ -44,10 +50,28 @@ public class Item {
     private String price;
 
     /*
-        등록자
+        사용자
     */
-    @Column(name = "register_person", nullable = false)
-    private String registerPerson;
+    @Column(name = "user", nullable = false)
+    private String user;
+
+    /*
+        대여 위치
+    */
+    @Column(name = "place", nullable = false)
+    private String place;
+
+    /*
+        반납일
+    */
+    @Column(name = "return_date", nullable = false)
+    private LocalDateTime returnDate;
+
+    /*
+        대여일
+    */
+    @Column(name = "rental_date", nullable = false)
+    private LocalDateTime rentalDate;
 
     /*
         사용 일수
@@ -55,25 +79,22 @@ public class Item {
     @Column(name = "usage_date", nullable = true)
     private Long usageDate;
 
-    /*
-        메모
-    */
-    @Column(name = "memo", nullable = true)
-    private String memo;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ItemStatus status = ItemStatus.AVAILABLE;
 
     @Builder
-    public Item(String item, String serialNumber, LocalDateTime acquisitionDate, String price, String registerPerson, Long usageDate, String memo, ItemStatus status) {
+    public Item(String item, String details, String serialNumber, LocalDateTime acquisitionDate, String price, String user, String place, LocalDateTime returnDate, LocalDateTime rentalDate, Long usageDate, ItemStatus status) {
         this.item = item;
+        this.details = details;
         this.serialNumber = serialNumber;
         this.acquisitionDate = acquisitionDate;
         this.price = price;
-        this.registerPerson = registerPerson;
+        this.user = user;
+        this.place = place;
+        this.returnDate = returnDate;
+        this.rentalDate = rentalDate;
         this.usageDate = usageDate;
-        this.memo = memo;
         this.status = status;
     }
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
@@ -13,6 +13,6 @@ public interface ItemMapper {
 
     ItemResponse entityToDto(Item entity);
     Item dtoToEntity(ItemRequest dto);
-    void updateItem(@MappingTarget Item target, ItemUpdateRequest source);
+
     List<ItemResponse> convertItemsToDtos(List<Item> items);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
@@ -4,6 +4,7 @@ import com.keepgoing.keepserver.domain.teacher.domain.entity.Item;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemResponse;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
 
 import java.util.List;
 
@@ -12,6 +13,6 @@ public interface ItemMapper {
 
     ItemResponse entityToDto(Item entity);
     Item dtoToEntity(ItemRequest dto);
-
+    void updateItem(@MappingTarget Item target, ItemRequest source);
     List<ItemResponse> convertItemsToDtos(List<Item> items);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/mapper/ItemMapper.java
@@ -2,9 +2,9 @@ package com.keepgoing.keepserver.domain.teacher.mapper;
 
 import com.keepgoing.keepserver.domain.teacher.domain.entity.Item;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemUpdateRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemResponse;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
+import org.mapstruct.*;
 
 import java.util.List;
 
@@ -13,6 +13,6 @@ public interface ItemMapper {
 
     ItemResponse entityToDto(Item entity);
     Item dtoToEntity(ItemRequest dto);
-    void updateItem(@MappingTarget Item target, ItemRequest source);
+    void updateItem(@MappingTarget Item target, ItemUpdateRequest source);
     List<ItemResponse> convertItemsToDtos(List<Item> items);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemRequest.java
@@ -20,7 +20,7 @@ public record ItemRequest (
         LocalDateTime acquisitionDate,
 
         @NotNull
-        String price,
+        Long price,
 
         @NotNull
         String place

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemRequest.java
@@ -11,6 +11,9 @@ public record ItemRequest (
         String item,
 
         @NotNull
+        String details,
+
+        @NotNull
         String serialNumber,
 
         @NotNull
@@ -20,5 +23,5 @@ public record ItemRequest (
         String price,
 
         @NotNull
-        String registerPerson
+        String place
 ) {}

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemStatusUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.keepgoing.keepserver.domain.teacher.payload.request;
+
+import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
+
+public record ItemStatusUpdateRequest(
+        Long itemId,
+        ItemStatus status
+) {}
+

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
@@ -9,12 +9,12 @@ public record ItemUpdateRequest(
         String details,
         String serialNumber,
         LocalDateTime acquisitionDate,
-        Integer price,
+        Long price,
         String rentedBy,
         String place,
         LocalDateTime returnDate,
         LocalDateTime rentalDate,
-        LocalDateTime usageDate,
+        Long usageDate,
         ItemStatus status
 ) {}
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.keepgoing.keepserver.domain.teacher.payload.request;
 
+import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
+
 import java.time.LocalDateTime;
 
 public record ItemUpdateRequest(
@@ -13,6 +15,6 @@ public record ItemUpdateRequest(
         LocalDateTime returnDate,
         LocalDateTime rentalDate,
         LocalDateTime usageDate,
-        String status
+        ItemStatus status
 ) {}
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
@@ -1,11 +1,5 @@
 package com.keepgoing.keepserver.domain.teacher.payload.request;
 
-import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 import java.time.LocalDateTime;
 
 public record ItemUpdateRequest(
@@ -18,7 +12,6 @@ public record ItemUpdateRequest(
         String place,
         LocalDateTime returnDate,
         LocalDateTime rentalDate,
-        LocalDateTime usageDate,
-        ItemStatus status
+        LocalDateTime usageDate
 ) {}
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
@@ -12,6 +12,7 @@ public record ItemUpdateRequest(
         String place,
         LocalDateTime returnDate,
         LocalDateTime rentalDate,
-        LocalDateTime usageDate
+        LocalDateTime usageDate,
+        String status
 ) {}
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/request/ItemUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.keepgoing.keepserver.domain.teacher.payload.request;
+
+import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+public record ItemUpdateRequest(
+        String item,
+        String details,
+        String serialNumber,
+        LocalDateTime acquisitionDate,
+        Integer price,
+        String rentedBy,
+        String place,
+        LocalDateTime returnDate,
+        LocalDateTime rentalDate,
+        LocalDateTime usageDate,
+        ItemStatus status
+) {}
+

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
@@ -1,5 +1,6 @@
 package com.keepgoing.keepserver.domain.teacher.payload.response;
 
+import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -16,6 +17,6 @@ public record ItemResponse(
         LocalDateTime returnDate,
         LocalDateTime rentalDate,
         Long usageDate,
-        String status
+        ItemStatus status
 ) {
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
@@ -11,8 +11,11 @@ public record ItemResponse(
         String serialNumber,
         LocalDateTime acquisitionDate,
         String price,
-        String registerPerson,
+        String user,
+        String place,
+        LocalDateTime returnDate,
+        LocalDateTime rentalDate,
         Long usageDate,
-        String memo
+        String status
 ) {
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
@@ -18,5 +18,4 @@ public record ItemResponse(
         LocalDateTime rentalDate,
         Long usageDate,
         ItemStatus status
-) {
-}
+) { }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
@@ -11,7 +11,7 @@ public record ItemResponse(
         String serialNumber,
         LocalDateTime acquisitionDate,
         String price,
-        String user,
+        String rentedBy,
         String place,
         LocalDateTime returnDate,
         LocalDateTime rentalDate,

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/payload/response/ItemResponse.java
@@ -11,7 +11,7 @@ public record ItemResponse(
         String item,
         String serialNumber,
         LocalDateTime acquisitionDate,
-        String price,
+        Long price,
         String rentedBy,
         String place,
         LocalDateTime returnDate,

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepserver.domain.teacher.presentation;
 
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemUpdateRequest;
 import com.keepgoing.keepserver.domain.teacher.service.ItemService;
 import com.keepgoing.keepserver.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class TeacherController {
     }
 
     @PatchMapping("/item/{id}")
-    public BaseResponse updateItem(@PathVariable Long id, @RequestBody ItemRequest request) {
+    public BaseResponse updateItem(@PathVariable Long id, @RequestBody ItemUpdateRequest request) {
         return itemService.updateItem(id, request);
     }
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepserver.domain.teacher.presentation;
 
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
 import com.keepgoing.keepserver.domain.teacher.service.ItemService;
 import com.keepgoing.keepserver.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,11 @@ public class TeacherController {
     @GetMapping("/item/count")
     public BaseResponse statusCount() {
         return itemService.statusCount();
+    }
+
+    @PatchMapping("/item/status")
+    public BaseResponse updateItemStatus(@RequestBody ItemStatusUpdateRequest request) {
+        return itemService.updateItemStatus(request);
     }
 
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
@@ -31,7 +31,7 @@ public class TeacherController {
         return itemService.readItem(id);
     }
 
-    @PutMapping("/item/{id}")
+    @PatchMapping("/item/{id}")
     public BaseResponse updateItem(@PathVariable Long id, @RequestBody ItemUpdateRequest request) {
         return itemService.updateItem(id, request);
     }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
@@ -31,7 +31,7 @@ public class TeacherController {
         return itemService.readItem(id);
     }
 
-    @PatchMapping("/item/{id}")
+    @PutMapping("/item/{id}")
     public BaseResponse updateItem(@PathVariable Long id, @RequestBody ItemUpdateRequest request) {
         return itemService.updateItem(id, request);
     }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/presentation/TeacherController.java
@@ -30,6 +30,11 @@ public class TeacherController {
         return itemService.readItem(id);
     }
 
+    @PatchMapping("/item/{id}")
+    public BaseResponse updateItem(@PathVariable Long id, @RequestBody ItemRequest request) {
+        return itemService.updateItem(id, request);
+    }
+
     @GetMapping("/item/count")
     public BaseResponse statusCount() {
         return itemService.statusCount();

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
@@ -2,6 +2,7 @@ package com.keepgoing.keepserver.domain.teacher.service;
 
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemUpdateRequest;
 import com.keepgoing.keepserver.global.common.BaseResponse;
 
 public interface ItemService {
@@ -9,6 +10,6 @@ public interface ItemService {
     BaseResponse statusCount();
     BaseResponse readItem(Long id);
     BaseResponse createItem(ItemRequest request);
-    BaseResponse updateItem(Long id, ItemRequest request);
+    BaseResponse updateItem(Long id, ItemUpdateRequest request);
     BaseResponse updateItemStatus(ItemStatusUpdateRequest request);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
@@ -9,5 +9,6 @@ public interface ItemService {
     BaseResponse statusCount();
     BaseResponse readItem(Long id);
     BaseResponse createItem(ItemRequest request);
+    BaseResponse updateItem(Long id, ItemRequest request);
     BaseResponse updateItemStatus(ItemStatusUpdateRequest request);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.keepgoing.keepserver.domain.teacher.service;
 
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
 import com.keepgoing.keepserver.global.common.BaseResponse;
 
 public interface ItemService {
@@ -8,4 +9,5 @@ public interface ItemService {
     BaseResponse statusCount();
     BaseResponse readItem(Long id);
     BaseResponse createItem(ItemRequest request);
+    BaseResponse updateItemStatus(ItemStatusUpdateRequest request);
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
@@ -61,5 +61,4 @@ public class ItemServiceImpl implements ItemService {
         );
     }
 
-
 }

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
@@ -6,6 +6,7 @@ import com.keepgoing.keepserver.domain.teacher.domain.repository.ItemRepository;
 import com.keepgoing.keepserver.domain.teacher.mapper.ItemMapper;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemUpdateRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemResponse;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemStatusCountResponse;
 import com.keepgoing.keepserver.global.common.BaseResponse;
@@ -49,7 +50,7 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     @Transactional
-    public BaseResponse updateItem(Long id, ItemRequest request) {
+    public BaseResponse updateItem(Long id, ItemUpdateRequest request) {
         Item item = itemRepository.findById(id)
                 .orElseThrow(ItemException::itemNotFound);
 

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
@@ -5,6 +5,7 @@ import com.keepgoing.keepserver.domain.teacher.domain.entity.enums.ItemStatus;
 import com.keepgoing.keepserver.domain.teacher.domain.repository.ItemRepository;
 import com.keepgoing.keepserver.domain.teacher.mapper.ItemMapper;
 import com.keepgoing.keepserver.domain.teacher.payload.request.ItemRequest;
+import com.keepgoing.keepserver.domain.teacher.payload.request.ItemStatusUpdateRequest;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemResponse;
 import com.keepgoing.keepserver.domain.teacher.payload.response.ItemStatusCountResponse;
 import com.keepgoing.keepserver.global.common.BaseResponse;
@@ -46,11 +47,24 @@ public class ItemServiceImpl implements ItemService {
         return new BaseResponse(HttpStatus.OK, "Successful query of managed item details", itemMapper.entityToDto(item));
     }
 
+    @Override
     @Transactional(readOnly = true)
     public BaseResponse statusCount() {
         ItemStatusCountResponse response = getItemStatusCount();
         return new BaseResponse(HttpStatus.OK, "Item status count retrieved successfully", response);
     }
+
+    @Override
+    @Transactional
+    public BaseResponse updateItemStatus(ItemStatusUpdateRequest request) {
+        Item item = itemRepository.findById(request.itemId())
+                .orElseThrow(ItemException::itemNotFound);
+
+        item.updateStatus(request.status());
+
+        return new BaseResponse(HttpStatus.OK, "Item status has been changed successfully");
+    }
+
 
     private ItemStatusCountResponse getItemStatusCount() {
         return new ItemStatusCountResponse(

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
@@ -48,6 +48,18 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
+    @Transactional
+    public BaseResponse updateItem(Long id, ItemRequest request) {
+        Item item = itemRepository.findById(id)
+                .orElseThrow(ItemException::itemNotFound);
+
+        itemMapper.updateItem(item, request);
+
+        return new BaseResponse(HttpStatus.OK, "Item information has been updated successfully.");
+    }
+
+
+    @Override
     @Transactional(readOnly = true)
     public BaseResponse statusCount() {
         ItemStatusCountResponse response = getItemStatusCount();

--- a/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
+++ b/src/main/java/com/keepgoing/keepserver/domain/teacher/service/ItemServiceImpl.java
@@ -54,7 +54,7 @@ public class ItemServiceImpl implements ItemService {
         Item item = itemRepository.findById(id)
                 .orElseThrow(ItemException::itemNotFound);
 
-        itemMapper.updateItem(item, request);
+        item.updateItem(request);
 
         return new BaseResponse(HttpStatus.OK, "Item information has been updated successfully.");
     }


### PR DESCRIPTION
확정된 요구사항에 맞춰 Item 엔티티를 수정하고, 상태 변경 / 수정 API를 추가했습니다.

처음에는 MapStruct + @MappingTarget을 활용하여 null 이 아닌 필드만 업데이트하는 방식을 고려했지만,
[자료1](https://www.inflearn.com/community/questions/251396/mapstruct-%EC%99%80-entity-setter-%EC%A7%88%EB%AC%B8?srsltid=AfmBOop6VAKzeltLLdDgX3xwnNFtXTCRb1MG2WEGz1x7M5YPbgMoaCsv) [자료2](https://ryumodrn.tistory.com/22) 를 통해 기존 엔티티를 직접 수정하는 대신 새로운 객체를 생성하여 교체하는 방식으로 구현했습니다.

@MappingTarget 사용 시 내부적으로 setter 를 호출하기 때문에  
엔티티 불변성이 깨질 수 있고, 의도치 않은 필드 변경 가능성도 있어 주의가 필요하다고 판단했습니다.

이에 따라, 엔티티에 @Setter 는 열지 않고 **null 체크 후 수동으로 필드 업데이트하는 방식**을 선택했습니다.